### PR TITLE
remove GTK3.10 check since it was not needed and this also prevents the ...

### DIFF
--- a/playlists_ie_prefs.ui
+++ b/playlists_ie_prefs.ui
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.16.1 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
   <object class="GtkBox" id="config">
     <property name="visible">True</property>
     <property name="can_focus">False</property>


### PR DESCRIPTION
...plugin being used on earlier GTK based distros
