### PR TITLE
Update playlists_ie.py

### DIFF
--- a/playlists_ie.py
+++ b/playlists_ie.py
@@ -142,7 +142,7 @@ class PlaylistLoadSavePlugin(GObject.Object, Peas.Activatable):
 
         self.progress_window.destroy()
 
-        def import_single_playlist(self, playlist, shell):
+    def import_single_playlist(self, playlist, shell):
         settings = Gio.Settings.new("org.gnome.rhythmbox.plugins.playlists_ie")
         folder = settings.get_string("ie-folder")  # get the import-export folder
         if not os.path.isdir(folder):


### PR DESCRIPTION
Fixes indentation error that results in plugin not loading and that was introduced by:
commit aa1889c4deef41bbe89d6aa5aa3f292bd24752d1
Author: lachlan <lachlan.00@gmail.com>
Date:   Thu Mar 1 12:09:12 2018 +1000