### PR TITLE
Add options for full import to skip matching file names

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,5 +79,9 @@ rm "${PLUGIN_PATH}${SCRIPT_NAME}"
 if [ ! -f $GLIB_DIR$GLIB_SCHEME ]; then
     echo "Installing the glib schema (password needed)" && sudo cp "${PLUGIN_PATH}${GLIB_SCHEME}" "$GLIB_DIR" && sudo glib-compile-schemas "$GLIB_DIR"
 fi
+# update the glib schema if different
+if ! cmp -s "${PLUGIN_PATH}${GLIB_SCHEME}" "${GLIB_DIR}${GLIB_SCHEME}"; then
+    echo "Updating the glib schema (password needed)" && sudo cp "${PLUGIN_PATH}${GLIB_SCHEME}" "$GLIB_DIR" && sudo glib-compile-schemas "$GLIB_DIR"
+fi
 
 read -p "Script execution ended, press [Enter] key to exit..."

--- a/org.gnome.rhythmbox.plugins.playlists_ie.gschema.xml
+++ b/org.gnome.rhythmbox.plugins.playlists_ie.gschema.xml
@@ -6,5 +6,10 @@
             <summary>Folder to import to or export from.</summary>
             <description>Defines the folder that the batch operations are applied to/from. There is no recursion into subfolders.</description>
         </key>
+        <key type="b" name="import-skip">
+            <default>false</default>
+            <summary>Do not delete existing playlists that match  names using "Import Playlists".</summary>
+            <description>Default behavious is to clear all non-auto playlists and import from the set folder. If set this will not delete matching playlist names.</description>
+        </key>
     </schema>
 </schemalist>

--- a/playlists_ie.py
+++ b/playlists_ie.py
@@ -96,10 +96,12 @@ class PlaylistLoadSavePlugin(GObject.Object, Peas.Activatable):
         self.create_progress_bar_win()
         pl_man = shell.props.playlist_manager
         pl_list = pl_man.get_playlists()
+        pl_names = []
         pl_count = len(pl_list)
         processed_pl_count = 0
 
         for playlist in pl_list:
+            pl_names.append(playlist.props.name)
 
             while Gtk.events_pending():
                 Gtk.main_iteration()
@@ -128,7 +130,7 @@ class PlaylistLoadSavePlugin(GObject.Object, Peas.Activatable):
 
             while Gtk.events_pending():
                 Gtk.main_iteration()
-            if importskip and pl_file[:-4] in pl_man.get_playlists():
+            if importskip and pl_file[:-4] in pl_names:
                 logging.error("Skipping file import " + pl_file)
             elif pl_file.endswith(".m3u"):
                 pl_name = pl_file[:-4]
@@ -253,7 +255,8 @@ class PlaylistLoadSavePlugin(GObject.Object, Peas.Activatable):
         widget.destroy()
 
     def create_progress_bar_win(self):
-
+        while Gtk.events_pending():
+                Gtk.main_iteration()
         self.progress_window = Gtk.Dialog(title="Import/export progress",
                                           parent=self.window)
 
@@ -267,6 +270,7 @@ class PlaylistLoadSavePlugin(GObject.Object, Peas.Activatable):
         self.progress_window.show_all()
 
     def update_fraction(self, fraction):
-
+        while Gtk.events_pending():
+                Gtk.main_iteration()
         self.progress_bar.pulse()
         self.progress_bar.set_fraction(fraction)

--- a/playlists_ie_prefs.py
+++ b/playlists_ie_prefs.py
@@ -22,8 +22,10 @@ class PlaylistsIOConfigureDialog (GObject.Object, PeasGtk.Configurable):
     def __init__(self):
         GObject.Object.__init__(self)
         self.config = None
+        self.chooser = None
         self.choose_button = None
         self.path_display = None
+        self.import_skip_box = None
 
     def do_create_configure_widget(self):
         builder = Gtk.Builder()
@@ -33,19 +35,23 @@ class PlaylistsIOConfigureDialog (GObject.Object, PeasGtk.Configurable):
 
         self.choose_button = builder.get_object("choose_button")
         self.path_display = builder.get_object("path_display")
+        self.import_skip_box = builder.get_object("import_skip_check")
 
         self.choose_button.connect("clicked", self.choose_callback)
         self.path_display.connect("changed", self.path_changed_callback)
+        self.import_skip_box.connect("toggled", self.import_skip_box_callback)
 
         settings = Gio.Settings.new("org.gnome.rhythmbox.plugins.playlists_ie")
         folder = settings.get_string("ie-folder")  # get the import-export folder
+        importskip = settings.get_boolean("import-skip")  # get import-skip boolean from settings
 
         self.path_display.set_text(folder)
+        self.import_skip_box.set_active(importskip)
 
         return self.config
 
     def choose_callback(self, widget):
-        def response_handler(widget, response):
+        def response_handler(responsewidget, response):
             if response == Gtk.ResponseType.OK:
                 path = self.chooser.get_filename()
                 self.chooser.destroy()
@@ -70,3 +76,9 @@ class PlaylistsIOConfigureDialog (GObject.Object, PeasGtk.Configurable):
 
         settings = Gio.Settings.new("org.gnome.rhythmbox.plugins.playlists_ie")
         settings.set_string("ie-folder", path)  # get the import-export folder
+
+    def import_skip_box_callback(self, widget):
+        active = self.import_skip_box.get_active()
+
+        settings = Gio.Settings.new("org.gnome.rhythmbox.plugins.playlists_ie")
+        settings.set_boolean("import-skip", active)  # set the import-skip status

--- a/playlists_ie_prefs.ui
+++ b/playlists_ie_prefs.ui
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.16.1 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkBox" id="config">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="margin_left">12</property>
+    <property name="margin_right">12</property>
     <property name="orientation">vertical</property>
     <property name="spacing">2</property>
     <child>
       <object class="GtkLabel" id="label1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="margin_top">4</property>
+        <property name="margin_bottom">4</property>
         <property name="label" translatable="yes">WARNING! Importing playlists deletes all current static playlists from Rhythmbox, so export first!</property>
         <property name="justify">center</property>
         <property name="wrap">True</property>
@@ -20,7 +25,7 @@
       </object>
       <packing>
         <property name="expand">False</property>
-        <property name="fill">True</property>
+        <property name="fill">False</property>
         <property name="position">0</property>
       </packing>
     </child>
@@ -51,8 +56,6 @@
       <object class="GtkBox" id="box2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
         <child>
           <object class="GtkEntry" id="path_display">
             <property name="visible">True</property>
@@ -82,6 +85,22 @@
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="import_skip_check">
+        <property name="label" translatable="yes">skip matching playlist names on import</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="margin_top">8</property>
+        <property name="margin_bottom">8</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">4</property>
       </packing>
     </child>
   </object>


### PR DESCRIPTION
I just thought this might be a good feature for others.

I've had some issue with the amount of time an initial import takes on remote file systems. so i've added an option to allow skipping matching names (off by default). That way it won't recreate existing playlists when an import fails or is cancelled.

With this option set it will ignore existing playlists when using "Import playlists" but will still replace individual playlists when using "Update this playlist"

Because this is a new gsettings option i've also updated the install script to update if the schema doesn't match using cmp.

This also means i've updated the UI file to allow setting this option with a few visual changes using glade.

I have tested remotely over sshfs and it made the process a lot faster than it's taken before. Thanks for writing such a useful plugin and i hope you like the extra options